### PR TITLE
Add API for custom welcome, review, and setup steps.

### DIFF
--- a/BrCredentialCreatorWizard.vue
+++ b/BrCredentialCreatorWizard.vue
@@ -27,8 +27,10 @@
             :currentStep="currentStep"
             :stepIndex="stepIndex"
             :vocab="vocab" />
-          <!-- TODO: support custom components
-            <component :is="stepComponent" /> -->
+          <component
+            :is="stepComponent"
+            v-else
+            v-bind="{currentStep, stepIndex, vocab}" />
         </div>
       </br-wizard-step>
     </br-wizard>
@@ -171,11 +173,9 @@ export default {
     stepComponent() {
       const {currentStep, stepComponentMap} = this;
       if(currentStep.component) {
-        const component = stepComponentMap[currentStep.component];
-        if(!component) {
-          return 'slot';
-        }
-      } else if(currentStep.form) {
+        return stepComponentMap[currentStep.component] || 'slot';
+      }
+      if(currentStep.form) {
         return 'form';
       }
       return null;

--- a/BrCustomStepMixin.js
+++ b/BrCustomStepMixin.js
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+export default {
+  props: {
+    currentStep: {
+      type: Object,
+      default: () => ({}),
+      required: true
+    },
+    stepIndex: {
+      type: Number,
+      default: 0,
+      required: true
+    },
+    vocab: {
+      type: Object,
+      default: () => ({}),
+      required: true
+    }
+  }
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add API for custom welcome, review, and slotted steps.
+- Export mixin for creating custom step components.
 
 ## 1.1.0 - 2019-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.0 - 2019-xx-xx
 
 ### Added
-- Add API for custom welcome, review, and setup steps.
+- Add API for custom welcome, review, and slotted steps.
 
 ## 1.1.0 - 2019-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-credential-creator-wizard ChangeLog
 
+## 1.2.0 - 2019-xx-xx
+
+### Added
+- Add API for custom welcome, review, and setup steps.
+
 ## 1.1.0 - 2019-04-16
 
 ### Updated

--- a/index.js
+++ b/index.js
@@ -5,3 +5,4 @@
 
 export {default as BrCredentialCreatorWizard} from
   './BrCredentialCreatorWizard.vue';
+export {default as BrCustomStepMixin} from './BrCustomStepMixin.js';

--- a/test/components/BrCustomStep.vue
+++ b/test/components/BrCustomStep.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    STEP {{stepIndex}} RENDERED VIA CUSTOM COMPONENT
+    <pre>{{currentStep}}</pre>
+  </div>
+</template>
+<script>
+/*!
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+import {BrCustomStepMixin} from 'bedrock-vue-credential-creator-wizard';
+
+export default {
+  name: 'BrCustomStep',
+  mixins: [BrCustomStepMixin]
+};
+</script>
+<style>
+</style>

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -11,10 +11,11 @@
         :schema-map="schemaMap"
         :templates="templates"
         :welcome="welcome"
+        :step-component-map="{'br-custom-step': 'br-custom-step'}"
         @finish="finish($event)">
         <template
           #default="{currentStep, stepIndex}">
-          Custom Step {{stepIndex}}
+          Step {{stepIndex}} rendered via slot
           <pre>{{currentStep}}</pre>
         </template>
       </br-credential-creator-wizard>
@@ -28,6 +29,10 @@
 'use strict';
 
 import {BrCredentialCreatorWizard} from 'bedrock-vue-credential-creator-wizard';
+import BrCustomStep from './BrCustomStep.vue';
+
+import Vue from 'vue';
+Vue.component('br-custom-step', BrCustomStep);
 
 export default {
   name: 'Home',
@@ -66,7 +71,7 @@ export default {
         heading: 'Custom Setup Heading 2',
         subheading: 'Custom setup subheading 2',
         name: 'Custom Setup Name 2',
-        component: 'slot'
+        component: 'br-custom-step'
       }, {
         icon: {
           name: 'far fa-list-alt',

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -11,9 +11,9 @@
         :schema-map="schemaMap"
         :templates="templates"
         :welcome="welcome"
-        :setup="setup"
         @finish="finish($event)">
-        <template #setup="{currentStep, stepIndex}">
+        <template
+          #default="{currentStep, stepIndex}">
           Custom Step {{stepIndex}}
           <pre>{{currentStep}}</pre>
         </template>
@@ -35,25 +35,6 @@ export default {
   data() {
     return {
       credentials: [],
-      setup: [{
-        icon: {
-          name: 'fas fa-walking',
-          size: '65px',
-          color: 'primary'
-        },
-        heading: 'Custom Setup Heading 1',
-        subheading: 'Custom setup subheading 1',
-        name: 'Custom Setup Name 1'
-      }, {
-        icon: {
-          name: 'fas fa-walking',
-          size: '65px',
-          color: 'primary'
-        },
-        heading: 'Custom Setup Heading 2',
-        subheading: 'Custom setup subheading 2',
-        name: 'Custom Setup Name 2'
-      }],
       welcome: {
         icon: {
           name: 'fas fa-walking',
@@ -67,6 +48,26 @@ export default {
         name: 'Custom Introduction'
       },
       flow: [{
+        icon: {
+          name: 'fas fa-walking',
+          size: '65px',
+          color: 'primary'
+        },
+        heading: 'Custom Setup Heading 1',
+        subheading: 'Custom setup subheading 1',
+        name: 'Custom Setup Name 1',
+        component: 'slot'
+      }, {
+        icon: {
+          name: 'fas fa-walking',
+          size: '65px',
+          color: 'primary'
+        },
+        heading: 'Custom Setup Heading 2',
+        subheading: 'Custom setup subheading 2',
+        name: 'Custom Setup Name 2',
+        component: 'slot'
+      }, {
         icon: {
           name: 'far fa-list-alt',
           size: '65px',

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -10,7 +10,14 @@
         :vocab="vocab"
         :schema-map="schemaMap"
         :templates="templates"
-        @finish="finish($event)" />
+        :welcome="welcome"
+        :setup="setup"
+        @finish="finish($event)">
+        <template #setup="{currentStep, stepIndex}">
+          Custom Step {{stepIndex}}
+          <pre>{{currentStep}}</pre>
+        </template>
+      </br-credential-creator-wizard>
     </div>
   </q-page>
 </template>
@@ -28,6 +35,37 @@ export default {
   data() {
     return {
       credentials: [],
+      setup: [{
+        icon: {
+          name: 'fas fa-walking',
+          size: '65px',
+          color: 'primary'
+        },
+        heading: 'Custom Setup Heading 1',
+        subheading: 'Custom setup subheading 1',
+        name: 'Custom Setup Name 1'
+      }, {
+        icon: {
+          name: 'fas fa-walking',
+          size: '65px',
+          color: 'primary'
+        },
+        heading: 'Custom Setup Heading 2',
+        subheading: 'Custom setup subheading 2',
+        name: 'Custom Setup Name 2'
+      }],
+      welcome: {
+        icon: {
+          name: 'fas fa-walking',
+          size: '65px',
+          color: 'primary'
+        },
+        heading: 'Custom welcome, let\'s get started!',
+        subheading:
+          'We need to walk through a few steps to collect information for ' +
+          `the credential.`,
+        name: 'Custom Introduction'
+      },
       flow: [{
         icon: {
           name: 'far fa-list-alt',


### PR DESCRIPTION
So this is one way to add the ability to customize the setup before the main credential flow. I'm not super happy with it because it is a bit rigid, but it does solve the problem without breaking backwards compatibility.

The "problem" is that we can't currently reuse this component when there are other setup steps necessary before the main VC flow can take place. Adding support for these other setup steps allows for other wizard flows that may include tasks like authenticating the user (e.g., via QRAM) prior to issuing VCs. This is desirable without having more than one "wizard" component (and in a way that avoids complex wizards in wizards, which is especially difficult given the UI).

This PR adds the ability to customize the welcome and review steps (without the ability to customize their content) and adds the ability to add an arbitrary number of setup steps *with* the ability to customize what elements they display via a named slot.

Thoughts, @gannan08, @davidlehn, @JoshDunnDev ?